### PR TITLE
remove GSoC 2021 notification

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,9 +22,6 @@ pitch: Offensive Web Testing Framework (OWTF), is an OWASP+PTES focused try to u
 
 ![logo](/assets/images/OWTFLogo.png){: .image-left }
 
-> # OWTF is taking part in the Google Summer of Code 2021 ! If you'd like to participate then see the [OWASP Google Summer of Code 2021 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2021ideas)!
-
-
 OWTF aims to make pen testing:
 
 * Aligned with OWASP Testing Guide + PTES + NIST

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ pitch: Offensive Web Testing Framework (OWTF), is an OWASP+PTES focused try to u
 
 ![logo](/assets/images/OWTFLogo.png){: .image-left }
 
-> # OWTF is taking part in the Google Summer of Code 2024 ! If you'd like to participate then see the [OWASP Google Summer of Code 2024 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas)!
+> # OWTF is taking part in the Google Summer of Code 2024 ! If you'd like to participate then see the [OWASP Google Summer of Code 2024 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas#owasp-owtf)!
 
 OWTF aims to make pen testing:
 

--- a/index.md
+++ b/index.md
@@ -22,6 +22,8 @@ pitch: Offensive Web Testing Framework (OWTF), is an OWASP+PTES focused try to u
 
 ![logo](/assets/images/OWTFLogo.png){: .image-left }
 
+# OWTF is taking part in the Google Summer of Code 2024 ! If you'd like to participate then see the [OWASP Google Summer of Code 2024 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas)!
+
 OWTF aims to make pen testing:
 
 * Aligned with OWASP Testing Guide + PTES + NIST

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ pitch: Offensive Web Testing Framework (OWTF), is an OWASP+PTES focused try to u
 
 ![logo](/assets/images/OWTFLogo.png){: .image-left }
 
-# OWTF is taking part in the Google Summer of Code 2024 ! If you'd like to participate then see the [OWASP Google Summer of Code 2024 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas)!
+> # OWTF is taking part in the Google Summer of Code 2024 ! If you'd like to participate then see the [OWASP Google Summer of Code 2024 Ideas page](https://owasp.org/www-community/initiatives/gsoc/gsoc2024ideas)!
 
 OWTF aims to make pen testing:
 


### PR DESCRIPTION
remove out of date Google Summer of Code 2021 notification and replace with link to GSoC 2024